### PR TITLE
Upgrade to nginx-proxy v4.0.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,51 +1,62 @@
-pipeline:
+kind: pipeline
+name: default
+type: kubernetes
 
-  build_image_pr:
-    image: docker:17.09.0-ce
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t nginx-proxy-govuk .
-    when:
-      event: pull_request
+platform:
+  os: linux
+  arch: amd64
 
-  build_image_tag:
-    image: docker:17.09.0-ce
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t "nginx-proxy-govuk:$${DRONE_TAG}" .
-    when:
-      event: tag
+steps:
+- name: build_image_pr
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  - docker build -t nginx-proxy-govuk .
+  when:
+    event:
+    - pull_request
 
-  push_image:
-    image: docker:17.09.0-ce
-    secrets:
-      - docker_password
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-      - DOCKER_IMAGE=nginx-proxy-govuk
-      - DOCKER_REPO=artifactory-internal.digital.homeoffice.gov.uk
-      - DOCKER_BASEDIR=/
-      - DOCKER_USERNAME=lev-web-robot
-    commands:
-      - docker login -u="$${DOCKER_USERNAME}" -p="$${DOCKER_PASSWORD}" "$${DOCKER_REPO}"
-      - ./publish.sh "nginx-proxy-govuk:$${DRONE_TAG}" "$${DOCKER_REPO}$${DOCKER_BASEDIR}$${DOCKER_IMAGE}" "$${DRONE_TAG}"
-    when:
-      event: tag
+- name: build_image_tag
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  - docker build -t "nginx-proxy-govuk:$${DRONE_TAG}" .
+  when:
+    event:
+    - tag
 
-  push_image_to_quay:
-    image: docker:17.09.0-ce
-    secrets:
-      - docker_quay_password
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-      - DOCKER_IMAGE=nginx-proxy-govuk
-      - DOCKER_REPO=quay.io
-      - DOCKER_BASEDIR=/ukhomeofficedigital/
-      - DOCKER_USERNAME=ukhomeofficedigital+nginx_proxy
-    commands:
-      - docker login -u="$${DOCKER_USERNAME}" -p="$${DOCKER_QUAY_PASSWORD}" "$${DOCKER_REPO}"
-      - ./publish.sh "nginx-proxy-govuk:$${DRONE_TAG}" "$${DOCKER_REPO}$${DOCKER_BASEDIR}$${DOCKER_IMAGE}" "$${DRONE_TAG}"
-    when:
-      event: tag
+- name: push_image_to_artifactory
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="$${DOCKER_USERNAME}" -p="$${DOCKER_PASSWORD}" "$${DOCKER_REPO}"
+  - ./publish.sh "nginx-proxy-govuk:$${DRONE_TAG}" "$${DOCKER_REPO}$${DOCKER_BASEDIR}$${DOCKER_IMAGE}" "$${DRONE_TAG}"
+  environment:
+    DOCKER_BASEDIR: /
+    DOCKER_IMAGE: nginx-proxy-govuk
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_REPO: artifactory-internal.digital.homeoffice.gov.uk
+    DOCKER_USERNAME: lev-web-robot
+  when:
+    event:
+    - tag
+
+- name: push_image_to_quay
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="$${DOCKER_USERNAME}" -p="$${DOCKER_QUAY_PASSWORD}" "$${DOCKER_REPO}"
+  - ./publish.sh "nginx-proxy-govuk:$${DRONE_TAG}" "$${DOCKER_REPO}$${DOCKER_BASEDIR}$${DOCKER_IMAGE}" "$${DRONE_TAG}"
+  environment:
+    DOCKER_BASEDIR: /ukhomeofficedigital/
+    DOCKER_IMAGE: nginx-proxy-govuk
+    DOCKER_QUAY_PASSWORD:
+      from_secret: docker_quay_password
+    DOCKER_REPO: quay.io
+    DOCKER_USERNAME: ukhomeofficedigital+nginx_proxy
+  when:
+    event:
+    - tag
+
+services:
+- name: docker
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/ukhomeofficedigital/nginx-proxy:v3.4.25
+FROM quay.io/ukhomeofficedigital/nginx-proxy:v4.0.1
 
 ADD ./html/ /usr/local/openresty/nginx/html/

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Simply a version of [docker-nginx-proxy] with GovUK-branded error
 pages. - Please read [the documentation for that image].
 
 ## Debugging
+
 To have the template render with more debugging information set `VERBOSE_ERROR_PAGES` to `TRUE`.
 
 In the terminal
-```
+
+```bash
 docker run -e "VERBOSE_ERROR_PAGES=TRUE" -p "10443:10443" nginx-proxy-govuk
 ```
 
 ## Additional error codes
+
 By default, [docker-nginx-proxy] only intercepts a subset of HTTP error codes.
 You can override the behaviour with `REDIRECT_ERROR_CODES`.
 
@@ -25,7 +28,7 @@ You can override the behaviour with `REDIRECT_ERROR_CODES`.
 ## Versioning
 
 This image will be versioned alongside the version of
-[docker-nginx-proxy] it consumes, with a minor build number taggen on
+[docker-nginx-proxy] it consumes, with a minor build number tagged on
 the end. For the versions available, see the [tags on this repository].
 
 ## Authors

--- a/publish.sh
+++ b/publish.sh
@@ -32,13 +32,13 @@ check_arg "${SRC}" "SRC"
 check_arg "${DEST}" "DEST"
 check_arg "${VERSION}" "VERSION"
 
-PATCH=`echo ${VERSION} | awk -F '.' '{print $1"."$2"."$3}'`
-MINOR=`echo ${PATCH} | awk -F '.' '{print $1"."$2}'`
-MAJOR=`echo ${MINOR} | awk -F '.' '{print $1}'`
+PATCH=$(echo "${VERSION}" | awk -F '.' '{print $1"."$2"."$3}')
+MINOR=$(echo "${PATCH}" | awk -F '.' '{print $1"."$2}')
+MAJOR=$(echo "${MINOR}" | awk -F '.' '{print $1}')
 
 tag_n_push() {
     FULL_NAME="${DEST}:${1}"
-    echo -n "Publishing '${SRC}' as '${FULL_NAME}'..."
+    printf "Publishing '%s' as '%s'..." "${SRC}" "${FULL_NAME}"
     docker tag "${SRC}" "${FULL_NAME}"
     docker push "${FULL_NAME}"
     echo " done."


### PR DESCRIPTION
* Upgraded to use docker-nginx-proxy:v4.0.1
* Upgraded `.drone.yml` to use Drone v1.0
  * Drone changes need someone access to:
    - [ ] Disable the old [Drone v0.8 repo](https://drone.acp.homeoffice.gov.uk/UKHomeOffice/docker-nginx-proxy-govuk)
    - [ ] Enable the new [Drone v1.0 repo](https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/docker-nginx-proxy-govuk/settings)
    - [ ] Copy over the appropriate Drone Secrets from 0.8 to 1.0

(While I think I could de/activate the repos, I don't have the knowlege to do the Drone Secrets, so haven't made any such changes)